### PR TITLE
fix: Improve error handling in data fetching script

### DIFF
--- a/app/fetch_data.php
+++ b/app/fetch_data.php
@@ -8,30 +8,60 @@ $servers = $conn->query("SELECT * FROM servers WHERE is_active = 1");
 
 if ($servers->num_rows > 0) {
     while($server = $servers->fetch_assoc()) {
+        echo "Fetching data for server: {$server['name']}...\n";
         $api = new WhmApi($server['host'], $server['username'], $server['api_token']);
+        $has_errors = false;
 
         // Fetch metrics
         $load_avg = $api->getLoadAvg();
-        $disk_usage = $api->getDiskUsage();
-        $version_info = $api->getVersion();
-        $backup_status = $api->getBackupStatus();
-
-        // Store metrics
-        if (isset($load_avg['data']['one'])) {
-            $load_str = "1m: {$load_avg['data']['one']}, 5m: {$load_avg['data']['five']}, 15m: {$load_avg['data']['fifteen']}";
-            $cpu_usage_str = null; // We are not fetching this separately for now
-            $disk_usage_json = isset($disk_usage['data']['partitions']) ? json_encode($disk_usage['data']['partitions']) : null;
-            $whm_version_str = isset($version_info['data']['version']) ? $version_info['data']['version'] : null;
-            $backup_status_json = isset($backup_status['data']['backup_config']) ? json_encode($backup_status['data']['backup_config']) : null;
-
-            $stmt = $conn->prepare("INSERT INTO server_metrics (server_id, load_avg, cpu_usage, disk_usage, whm_version, backup_status, created_at) VALUES (?, ?, ?, ?, ?, ?, NOW())");
-            $stmt->bind_param("isssss", $server['id'], $load_str, $cpu_usage_str, $disk_usage_json, $whm_version_str, $backup_status_json);
-            $stmt->execute();
-            $stmt->close();
+        if (isset($load_avg['error'])) {
+            echo " - Error fetching load average: " . $load_avg['error'] . "\n";
+            $load_avg = null;
+            $has_errors = true;
         }
+
+        $disk_usage = $api->getDiskUsage();
+        if (isset($disk_usage['error'])) {
+            echo " - Error fetching disk usage: " . $disk_usage['error'] . "\n";
+            $disk_usage = null;
+            $has_errors = true;
+        }
+
+        $version_info = $api->getVersion();
+        if (isset($version_info['error'])) {
+            echo " - Error fetching version: " . $version_info['error'] . "\n";
+            $version_info = null;
+            $has_errors = true;
+        }
+
+        $backup_status = $api->getBackupStatus();
+        if (isset($backup_status['error'])) {
+            echo " - Error fetching backup status: " . $backup_status['error'] . "\n";
+            $backup_status = null;
+            $has_errors = true;
+        }
+
+        // Prepare data for insertion
+        $load_str = isset($load_avg['data']['one']) ? "1m: {$load_avg['data']['one']}, 5m: {$load_avg['data']['five']}, 15m: {$load_avg['data']['fifteen']}" : null;
+        $cpu_usage_str = null; // Not implemented
+        $disk_usage_json = isset($disk_usage['data']['partitions']) ? json_encode($disk_usage['data']['partitions']) : null;
+        $whm_version_str = isset($version_info['data']['version']) ? $version_info['data']['version'] : null;
+        $backup_status_json = isset($backup_status['data']['backup_config']) ? json_encode($backup_status['data']['backup_config']) : null;
+
+        // Insert whatever data we have
+        $stmt = $conn->prepare("INSERT INTO server_metrics (server_id, load_avg, cpu_usage, disk_usage, whm_version, backup_status, created_at) VALUES (?, ?, ?, ?, ?, ?, NOW())");
+        $stmt->bind_param("isssss", $server['id'], $load_str, $cpu_usage_str, $disk_usage_json, $whm_version_str, $backup_status_json);
+        $stmt->execute();
+        $stmt->close();
 
         // Fetch and store SSL certs
         $ssl_certs = $api->getInstalledSslCerts(null);
+        if (isset($ssl_certs['error'])) {
+            echo " - Error fetching SSL certs: " . $ssl_certs['error'] . "\n";
+            $ssl_certs = null;
+            $has_errors = true;
+        }
+
         if (isset($ssl_certs['data']['vhosts'])) {
             // Clear old certs for this server
             $stmt = $conn->prepare("DELETE FROM ssl_certificates WHERE server_id = ?");
@@ -59,7 +89,11 @@ if ($servers->num_rows > 0) {
         $stmt->execute();
         $stmt->close();
 
-        echo "Successfully fetched data for server: {$server['name']}\n";
+        if ($has_errors) {
+            echo "Finished fetching data for server: {$server['name']} with some errors.\n";
+        } else {
+            echo "Successfully fetched all data for server: {$server['name']}\n";
+        }
     }
 } else {
     echo "No active servers found.\n";


### PR DESCRIPTION
This commit improves the error handling in the app/fetch_data.php script. It now reports errors encountered during WHM API calls instead of failing silently. This helps in debugging issues where the dashboard shows "No data". The script will now attempt to fetch all metrics even if some API calls fail, and will report a summary of any errors encountered.