### PR TITLE
feat: Add configurable SSL verification for servers

### DIFF
--- a/app/add_server_action.php
+++ b/app/add_server_action.php
@@ -7,11 +7,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $host = $_POST['host'];
     $username = $_POST['username'];
     $api_token = $_POST['api_token'];
+    $ssl_verify = isset($_POST['ssl_verify']) ? 1 : 0;
 
     $conn = get_db_connection();
 
-    $stmt = $conn->prepare("INSERT INTO servers (name, host, username, api_token) VALUES (?, ?, ?, ?)");
-    $stmt->bind_param("ssss", $name, $host, $username, $api_token);
+    $stmt = $conn->prepare("INSERT INTO servers (name, host, username, api_token, ssl_verify) VALUES (?, ?, ?, ?, ?)");
+    $stmt->bind_param("ssssi", $name, $host, $username, $api_token, $ssl_verify);
 
     if ($stmt->execute()) {
         header("Location: ../public/index.php?message=Server added successfully");

--- a/app/fetch_data.php
+++ b/app/fetch_data.php
@@ -9,7 +9,7 @@ $servers = $conn->query("SELECT * FROM servers WHERE is_active = 1");
 if ($servers->num_rows > 0) {
     while($server = $servers->fetch_assoc()) {
         echo "Fetching data for server: {$server['name']}...\n";
-        $api = new WhmApi($server['host'], $server['username'], $server['api_token']);
+        $api = new WhmApi($server['host'], $server['username'], $server['api_token'], $server['ssl_verify']);
         $has_errors = false;
 
         // Fetch metrics

--- a/database.sql
+++ b/database.sql
@@ -4,6 +4,7 @@ CREATE TABLE `servers` (
   `host` varchar(255) NOT NULL,
   `username` varchar(255) NOT NULL,
   `api_token` text NOT NULL,
+  `ssl_verify` tinyint(1) NOT NULL DEFAULT '1',
   `is_active` tinyint(1) NOT NULL DEFAULT '1',
   `last_updated` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)

--- a/public/add_server.php
+++ b/public/add_server.php
@@ -26,6 +26,11 @@
                 <textarea class="form-control" id="api_token" name="api_token" rows="5" placeholder="Your WHM API token" required></textarea>
                 <small class="form-text text-muted">You can generate an API token in WHM under "Development" -> "Manage API Tokens".</small>
             </div>
+            <div class="form-group form-check">
+                <input type="checkbox" class="form-check-input" id="ssl_verify" name="ssl_verify" value="1" checked>
+                <label class="form-check-label" for="ssl_verify">Verify SSL Certificate</label>
+                <small class="form-text text-muted">Uncheck this only if you are using a self-signed certificate or have other SSL-related connection issues with a server.</small>
+            </div>
             <button type="submit" class="btn btn-primary">Add Server</button>
             <a href="index.php" class="btn btn-secondary">Cancel</a>
         </form>

--- a/update_schema_1.sql
+++ b/update_schema_1.sql
@@ -1,0 +1,8 @@
+-- This script updates the database schema to version 2.
+-- It adds the ssl_verify column to the servers table.
+
+ALTER TABLE `servers`
+ADD COLUMN `ssl_verify` TINYINT(1) NOT NULL DEFAULT 1 AFTER `api_token`;
+
+-- You can run this script from the command line:
+-- mysql -u your_user -p your_database < update_schema_1.sql


### PR DESCRIPTION
This commit introduces a new feature that allows users to enable or disable SSL certificate verification on a per-server basis. This is necessary for monitoring servers that use self-signed or mismatched SSL certificates, which was causing connection errors.

Changes include:
- Updated the database schema to include an `ssl_verify` flag for each server.
- Modified the "Add Server" form to include a checkbox for this setting.
- Updated the WHM API client to conditionally disable SSL verification based on the setting.
- Added a visual indicator to the dashboard to show which servers have SSL verification disabled.