### PR TITLE
fix: Remove problematic database migration script

### DIFF
--- a/update_schema_1.sql
+++ b/update_schema_1.sql
@@ -1,8 +1,0 @@
--- This script updates the database schema to version 2.
--- It adds the ssl_verify column to the servers table.
-
-ALTER TABLE `servers`
-ADD COLUMN `ssl_verify` TINYINT(1) NOT NULL DEFAULT 1 AFTER `api_token`;
-
--- You can run this script from the command line:
--- mysql -u your_user -p your_database < update_schema_1.sql


### PR DESCRIPTION
Removes the `update_schema_1.sql` migration script which was reported to cause errors.

The main `database.sql` file is correct and contains the final schema for a fresh installation. This change leaves the repository in a clean state for users starting from scratch.